### PR TITLE
add missing import

### DIFF
--- a/crates/stateless/src/validation.rs
+++ b/crates/stateless/src/validation.rs
@@ -1,4 +1,4 @@
-use crate::{trie::StatelessTrie, witness_db::WitnessDatabase, ExecutionWitness};
+use crate::{track_cycles, trie::StatelessTrie, witness_db::WitnessDatabase, ExecutionWitness};
 use alloc::{
     boxed::Box,
     collections::BTreeMap,


### PR DESCRIPTION
@kevaundray, looks like in [this previous `main` merge](https://github.com/kevaundray/reth/pull/8/commits/5117f87d27756f79705f993e3fb9e078e645cd5f#diff-8b0db3bf59e71b10125dd89763181e1ba8213c01d03bb568d8b3a43b0a060243R1) this import was lost and the crate stopped compiling.

Realized when trying to [update](https://github.com/eth-act/zkevm-benchmark-workload/pull/85) in the workload repo.