### PR TITLE
Experimental: Fusaka Devnet 2 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 version = "1.5.0"
 edition = "2021"
-rust-version = "1.86"
+rust-version = "1.85"
 license = "MIT OR Apache-2.0"
 homepage = "https://paradigmxyz.github.io/reth"
 repository = "https://github.com/paradigmxyz/reth"
@@ -310,7 +310,7 @@ strip = "none"
 
 # Include debug info in benchmarks too.
 [profile.bench]
-inherits = "profiling"
+inherits = "release"
 
 [profile.maxperf]
 inherits = "release"
@@ -468,8 +468,12 @@ alloy-chains = { version = "0.2.0", default-features = false }
 alloy-dyn-abi = "1.2.0"
 alloy-eip2124 = { version = "0.2.0", default-features = false }
 alloy-evm = { version = "0.13", default-features = false }
-alloy-primitives = { version = "1.2.0", default-features = false, features = ["map-foldhash"] }
-alloy-rlp = { version = "0.3.10", default-features = false, features = ["core-net"] }
+alloy-primitives = { version = "1.2.0", default-features = false, features = [
+    "map-foldhash",
+] }
+alloy-rlp = { version = "0.3.10", default-features = false, features = [
+    "core-net",
+] }
 alloy-sol-macro = "1.1.0"
 alloy-sol-types = { version = "1.2.0", default-features = false }
 alloy-trie = { version = "0.9.0", default-features = false }
@@ -483,10 +487,14 @@ alloy-genesis = { version = "1.0.16", default-features = false }
 alloy-json-rpc = { version = "1.0.16", default-features = false }
 alloy-network = { version = "1.0.16", default-features = false }
 alloy-network-primitives = { version = "1.0.16", default-features = false }
-alloy-provider = { version = "1.0.16", features = ["reqwest"], default-features = false }
+alloy-provider = { version = "1.0.16", features = [
+    "reqwest",
+], default-features = false }
 alloy-pubsub = { version = "1.0.16", default-features = false }
 alloy-rpc-client = { version = "1.0.16", default-features = false }
-alloy-rpc-types = { version = "1.0.16", features = ["eth"], default-features = false }
+alloy-rpc-types = { version = "1.0.16", features = [
+    "eth",
+], default-features = false }
 alloy-rpc-types-admin = { version = "1.0.16", default-features = false }
 alloy-rpc-types-anvil = { version = "1.0.16", default-features = false }
 alloy-rpc-types-beacon = { version = "1.0.16", default-features = false }
@@ -500,7 +508,9 @@ alloy-serde = { version = "1.0.16", default-features = false }
 alloy-signer = { version = "1.0.16", default-features = false }
 alloy-signer-local = { version = "1.0.16", default-features = false }
 alloy-transport = { version = "1.0.16" }
-alloy-transport-http = { version = "1.0.16", features = ["reqwest-rustls-tls"], default-features = false }
+alloy-transport-http = { version = "1.0.16", features = [
+    "reqwest-rustls-tls",
+], default-features = false }
 alloy-transport-ipc = { version = "1.0.16", default-features = false }
 alloy-transport-ws = { version = "1.0.16", default-features = false }
 
@@ -517,7 +527,10 @@ op-alloy-flz = { version = "0.13.1", default-features = false }
 # misc
 aquamarine = "0.6"
 auto_impl = "1"
-backon = { version = "1.2", default-features = false, features = ["std-blocking-sleep", "tokio-sleep"] }
+backon = { version = "1.2", default-features = false, features = [
+    "std-blocking-sleep",
+    "tokio-sleep",
+] }
 bincode = "1.3"
 bitflags = "2.4"
 blake3 = "1.5.5"
@@ -538,9 +551,13 @@ itertools = { version = "0.14", default-features = false }
 linked_hash_set = "0.1"
 lz4 = "1.28.1"
 modular-bitfield = "0.11.2"
-notify = { version = "8.0.0", default-features = false, features = ["macos_fsevent"] }
+notify = { version = "8.0.0", default-features = false, features = [
+    "macos_fsevent",
+] }
 nybbles = { version = "0.4.0", default-features = false }
-once_cell = { version = "1.19", default-features = false, features = ["critical-section"] }
+once_cell = { version = "1.19", default-features = false, features = [
+    "critical-section",
+] }
 parking_lot = "0.12"
 paste = "1.0"
 rand = "0.9"
@@ -618,7 +635,10 @@ proptest-arbitrary-interop = "0.1.0"
 # crypto
 enr = { version = "0.13", default-features = false }
 k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
-secp256k1 = { version = "0.30", default-features = false, features = ["global-context", "recovery"] }
+secp256k1 = { version = "0.30", default-features = false, features = [
+    "global-context",
+    "recovery",
+] }
 # rand 8 for secp256k1
 rand_08 = { package = "rand", version = "0.8" }
 

--- a/crates/stateless/src/fork_spec.rs
+++ b/crates/stateless/src/fork_spec.rs
@@ -57,6 +57,8 @@ pub enum ForkSpec {
     Cancun,
     /// Prague
     Prague,
+    /// Osaka
+    Osaka,
 }
 
 impl From<ForkSpec> for ChainSpec {
@@ -89,6 +91,7 @@ impl From<ForkSpec> for ChainSpec {
                 panic!("Overridden with PETERSBURG")
             }
             ForkSpec::Prague => spec_builder.prague_activated(),
+            ForkSpec::Osaka => spec_builder.prague_activated(),
         }
         .build()
     }

--- a/crates/stateless/src/fork_spec.rs
+++ b/crates/stateless/src/fork_spec.rs
@@ -91,7 +91,7 @@ impl From<ForkSpec> for ChainSpec {
                 panic!("Overridden with PETERSBURG")
             }
             ForkSpec::Prague => spec_builder.prague_activated(),
-            ForkSpec::Osaka => spec_builder.prague_activated(),
+            ForkSpec::Osaka => spec_builder.osaka_activated(),
         }
         .build()
     }

--- a/crates/stateless/src/fork_spec.rs
+++ b/crates/stateless/src/fork_spec.rs
@@ -1,0 +1,95 @@
+// This is here so we don't pull in the EF-tests.
+// We need to think more about how we will parse in the chain-spec
+use reth_chainspec::{ChainSpec, ChainSpecBuilder};
+use serde::{Deserialize, Serialize};
+
+/// Fork specification.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Hash, Ord, Clone, Copy, Serialize, Deserialize)]
+pub enum ForkSpec {
+    /// Frontier
+    Frontier,
+    /// Frontier to Homestead
+    FrontierToHomesteadAt5,
+    /// Homestead
+    Homestead,
+    /// Homestead to Tangerine
+    HomesteadToDaoAt5,
+    /// Homestead to Tangerine
+    HomesteadToEIP150At5,
+    /// Tangerine
+    EIP150,
+    /// Spurious Dragon
+    EIP158, // EIP-161: State trie clearing
+    /// Spurious Dragon to Byzantium
+    EIP158ToByzantiumAt5,
+    /// Byzantium
+    Byzantium,
+    /// Byzantium to Constantinople
+    ByzantiumToConstantinopleAt5, // SKIPPED
+    /// Byzantium to Constantinople
+    ByzantiumToConstantinopleFixAt5,
+    /// Constantinople
+    Constantinople, // SKIPPED
+    /// Constantinople fix
+    ConstantinopleFix,
+    /// Istanbul
+    Istanbul,
+    /// Berlin
+    Berlin,
+    /// Berlin to London
+    BerlinToLondonAt5,
+    /// London
+    London,
+    /// Paris aka The Merge
+    Merge,
+    /// Shanghai
+    Shanghai,
+    /// Merge EOF test
+    #[serde(alias = "Merge+3540+3670")]
+    MergeEOF,
+    /// After Merge Init Code test
+    #[serde(alias = "Merge+3860")]
+    MergeMeterInitCode,
+    /// After Merge plus new PUSH0 opcode
+    #[serde(alias = "Merge+3855")]
+    MergePush0,
+    /// Cancun
+    Cancun,
+    /// Prague
+    Prague,
+}
+
+impl From<ForkSpec> for ChainSpec {
+    fn from(fork_spec: ForkSpec) -> Self {
+        let spec_builder = ChainSpecBuilder::mainnet();
+
+        match fork_spec {
+            ForkSpec::Frontier => spec_builder.frontier_activated(),
+            ForkSpec::Homestead | ForkSpec::FrontierToHomesteadAt5 => {
+                spec_builder.homestead_activated()
+            }
+            ForkSpec::EIP150 | ForkSpec::HomesteadToDaoAt5 | ForkSpec::HomesteadToEIP150At5 => {
+                spec_builder.tangerine_whistle_activated()
+            }
+            ForkSpec::EIP158 => spec_builder.spurious_dragon_activated(),
+            ForkSpec::Byzantium
+            | ForkSpec::EIP158ToByzantiumAt5
+            | ForkSpec::ConstantinopleFix
+            | ForkSpec::ByzantiumToConstantinopleFixAt5 => spec_builder.byzantium_activated(),
+            ForkSpec::Istanbul => spec_builder.istanbul_activated(),
+            ForkSpec::Berlin => spec_builder.berlin_activated(),
+            ForkSpec::London | ForkSpec::BerlinToLondonAt5 => spec_builder.london_activated(),
+            ForkSpec::Merge
+            | ForkSpec::MergeEOF
+            | ForkSpec::MergeMeterInitCode
+            | ForkSpec::MergePush0 => spec_builder.paris_activated(),
+            ForkSpec::Shanghai => spec_builder.shanghai_activated(),
+            ForkSpec::Cancun => spec_builder.cancun_activated(),
+            ForkSpec::ByzantiumToConstantinopleAt5 | ForkSpec::Constantinople => {
+                panic!("Overridden with PETERSBURG")
+            }
+            ForkSpec::Prague => spec_builder.prague_activated(),
+        }
+        .build()
+    }
+}

--- a/crates/stateless/src/lib.rs
+++ b/crates/stateless/src/lib.rs
@@ -47,6 +47,19 @@ pub use validation::stateless_validation_with_trie;
 pub mod validation;
 pub(crate) mod witness_db;
 
+/// ForkSpec module
+/// This is needed because ChainSpec is not serializable (neither is genesis)
+///
+/// Note: There is an exact copy of ForkSpec in `ef-tests` but since ef-tests is not no_std
+/// we cannot pull that in since we need ForkSpec in the guest program.
+///
+/// We convert the ef-tests version of ForkSpec in the host into the one located in here.
+///
+/// When we parse execution spec tests, we get back a ForkSpec, that we then pass into
+/// the guest program and convert it into a ChainSpec. If someone is using Hoodi/Mainnet
+/// etc, then this may not be needed, as you can just do ChainSpec::mainnet() in the guest program
+pub mod fork_spec;
+
 #[doc(inline)]
 pub use alloy_rpc_types_debug::ExecutionWitness;
 

--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -49,7 +49,7 @@ impl Suite for BlockchainTests {
 /// An Ethereum blockchain test.
 #[derive(Debug, PartialEq, Eq)]
 pub struct BlockchainTestCase {
-    tests: BTreeMap<String, BlockchainTest>,
+    pub tests: BTreeMap<String, BlockchainTest>,
     skip: bool,
 }
 
@@ -183,7 +183,7 @@ impl Case for BlockchainTestCase {
 /// Returns:
 /// - `Ok(())` if all blocks execute successfully and the final state is correct.
 /// - `Err(Error)` if any block fails to execute correctly, or if the post-state validation fails.
-fn run_case(
+pub fn run_case(
     case: &BlockchainTest,
 ) -> Result<Vec<(RecoveredBlock<Block>, ExecutionWitness)>, Error> {
     // Create a new test database and initialize a provider for the test case.

--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -58,12 +58,12 @@ impl BlockchainTestCase {
     const fn excluded_fork(network: ForkSpec) -> bool {
         matches!(
             network,
-            ForkSpec::ByzantiumToConstantinopleAt5 |
-                ForkSpec::Constantinople |
-                ForkSpec::ConstantinopleFix |
-                ForkSpec::MergeEOF |
-                ForkSpec::MergeMeterInitCode |
-                ForkSpec::MergePush0
+            ForkSpec::ByzantiumToConstantinopleAt5
+                | ForkSpec::Constantinople
+                | ForkSpec::ConstantinopleFix
+                | ForkSpec::MergeEOF
+                | ForkSpec::MergeMeterInitCode
+                | ForkSpec::MergePush0
         )
     }
 
@@ -96,7 +96,7 @@ impl BlockchainTestCase {
         let expectation = Self::expected_failure(case);
         match run_case(case) {
             // All blocks executed successfully.
-            Ok(()) => {
+            Ok(_) => {
                 // Check if the test case specifies that it should have failed
                 if let Some((block, msg)) = expectation {
                     Err(Error::Assertion(format!(
@@ -122,7 +122,7 @@ impl BlockchainTestCase {
                 ))),
 
                 // No failure expected at all - bubble up original error.
-                None => err,
+                None => Err(err.unwrap_err()),
             },
 
             // Non‑processing error – forward as‑is.
@@ -157,7 +157,7 @@ impl Case for BlockchainTestCase {
     fn run(&self) -> Result<(), Error> {
         // If the test is marked for skipping, return a Skipped error immediately.
         if self.skip {
-            return Err(Error::Skipped)
+            return Err(Error::Skipped);
         }
 
         // Iterate through test cases, filtering by the network type to exclude specific forks.
@@ -183,7 +183,9 @@ impl Case for BlockchainTestCase {
 /// Returns:
 /// - `Ok(())` if all blocks execute successfully and the final state is correct.
 /// - `Err(Error)` if any block fails to execute correctly, or if the post-state validation fails.
-fn run_case(case: &BlockchainTest) -> Result<(), Error> {
+fn run_case(
+    case: &BlockchainTest,
+) -> Result<Vec<(RecoveredBlock<Block>, ExecutionWitness)>, Error> {
     // Create a new test database and initialize a provider for the test case.
     let chain_spec: Arc<ChainSpec> = Arc::new(case.network.into());
     let factory = create_test_provider_factory_with_chain_spec(chain_spec.clone());
@@ -283,7 +285,7 @@ fn run_case(case: &BlockchainTest) -> Result<(), Error> {
             return Err(Error::block_failed(
                 block_number,
                 Error::Assertion("state root mismatch".to_string()),
-            ))
+            ));
         }
 
         // Commit the post state/state diff to the database
@@ -315,23 +317,29 @@ fn run_case(case: &BlockchainTest) -> Result<(), Error> {
     // - Either an issue with the test setup
     // - Possibly an error in the test case where the post-state root in the last block does not
     //   match the post-state values.
-    let expected_post_state = case.post_state.as_ref().ok_or(Error::MissingPostState)?;
-    for (&address, account) in expected_post_state {
-        account.assert_db(address, provider.tx_ref())?;
-    }
+    match case.post_state.as_ref() {
+        Some(expected_post_state) => {
+            for (&address, account) in expected_post_state {
+                account.assert_db(address, provider.tx_ref())?;
+            }
+        }
+        None => {
+            // Do nothing
+        }
+    };
 
     // Now validate using the stateless client if everything else passes
-    for (block, execution_witness) in program_inputs {
+    for (block, execution_witness) in &program_inputs {
         stateless_validation(
-            block.into_block(),
-            execution_witness,
+            block.clone().into_block(),
+            execution_witness.clone(),
             chain_spec.clone(),
             EthEvmConfig::new(chain_spec.clone()),
         )
         .expect("stateless validation failed");
     }
 
-    Ok(())
+    Ok(program_inputs)
 }
 
 fn decode_blocks(

--- a/testing/ef-tests/src/models.rs
+++ b/testing/ef-tests/src/models.rs
@@ -310,6 +310,8 @@ pub enum ForkSpec {
     Cancun,
     /// Prague
     Prague,
+    /// Osaka
+    Osaka,
 }
 
 impl From<ForkSpec> for ChainSpec {
@@ -342,6 +344,7 @@ impl From<ForkSpec> for ChainSpec {
                 panic!("Overridden with PETERSBURG")
             }
             ForkSpec::Prague => spec_builder.prague_activated(),
+            ForkSpec::Osaka => spec_builder.osaka_activated(),
         }
         .build()
     }
@@ -384,6 +387,7 @@ impl From<ForkSpec> for reth_stateless::fork_spec::ForkSpec {
             ForkSpec::MergePush0 => reth_stateless::fork_spec::ForkSpec::MergePush0,
             ForkSpec::Cancun => reth_stateless::fork_spec::ForkSpec::Cancun,
             ForkSpec::Prague => reth_stateless::fork_spec::ForkSpec::Prague,
+            ForkSpec::Osaka => reth_stateless::fork_spec::ForkSpec::Osaka,
         }
     }
 }

--- a/testing/ef-tests/src/models.rs
+++ b/testing/ef-tests/src/models.rs
@@ -243,12 +243,12 @@ impl Account {
                 } else {
                     return Err(Error::Assertion(format!(
                         "Slot {slot:?} is missing from the database. Expected {value:?}"
-                    )))
+                    )));
                 }
             } else {
                 return Err(Error::Assertion(format!(
                     "Slot {slot:?} is missing from the database. Expected {value:?}"
-                )))
+                )));
             }
         }
 
@@ -325,17 +325,17 @@ impl From<ForkSpec> for ChainSpec {
                 spec_builder.tangerine_whistle_activated()
             }
             ForkSpec::EIP158 => spec_builder.spurious_dragon_activated(),
-            ForkSpec::Byzantium |
-            ForkSpec::EIP158ToByzantiumAt5 |
-            ForkSpec::ConstantinopleFix |
-            ForkSpec::ByzantiumToConstantinopleFixAt5 => spec_builder.byzantium_activated(),
+            ForkSpec::Byzantium
+            | ForkSpec::EIP158ToByzantiumAt5
+            | ForkSpec::ConstantinopleFix
+            | ForkSpec::ByzantiumToConstantinopleFixAt5 => spec_builder.byzantium_activated(),
             ForkSpec::Istanbul => spec_builder.istanbul_activated(),
             ForkSpec::Berlin => spec_builder.berlin_activated(),
             ForkSpec::London | ForkSpec::BerlinToLondonAt5 => spec_builder.london_activated(),
-            ForkSpec::Merge |
-            ForkSpec::MergeEOF |
-            ForkSpec::MergeMeterInitCode |
-            ForkSpec::MergePush0 => spec_builder.paris_activated(),
+            ForkSpec::Merge
+            | ForkSpec::MergeEOF
+            | ForkSpec::MergeMeterInitCode
+            | ForkSpec::MergePush0 => spec_builder.paris_activated(),
             ForkSpec::Shanghai => spec_builder.shanghai_activated(),
             ForkSpec::Cancun => spec_builder.cancun_activated(),
             ForkSpec::ByzantiumToConstantinopleAt5 | ForkSpec::Constantinople => {
@@ -344,6 +344,47 @@ impl From<ForkSpec> for ChainSpec {
             ForkSpec::Prague => spec_builder.prague_activated(),
         }
         .build()
+    }
+}
+
+impl From<ForkSpec> for reth_stateless::fork_spec::ForkSpec {
+    fn from(value: ForkSpec) -> Self {
+        match value {
+            ForkSpec::Frontier => reth_stateless::fork_spec::ForkSpec::Frontier,
+            ForkSpec::FrontierToHomesteadAt5 => {
+                reth_stateless::fork_spec::ForkSpec::FrontierToHomesteadAt5
+            }
+            ForkSpec::Homestead => reth_stateless::fork_spec::ForkSpec::Homestead,
+            ForkSpec::HomesteadToDaoAt5 => reth_stateless::fork_spec::ForkSpec::HomesteadToDaoAt5,
+            ForkSpec::HomesteadToEIP150At5 => {
+                reth_stateless::fork_spec::ForkSpec::HomesteadToEIP150At5
+            }
+            ForkSpec::EIP150 => reth_stateless::fork_spec::ForkSpec::EIP150,
+            ForkSpec::EIP158 => reth_stateless::fork_spec::ForkSpec::EIP158,
+            ForkSpec::EIP158ToByzantiumAt5 => {
+                reth_stateless::fork_spec::ForkSpec::EIP158ToByzantiumAt5
+            }
+            ForkSpec::Byzantium => reth_stateless::fork_spec::ForkSpec::Byzantium,
+            ForkSpec::ByzantiumToConstantinopleAt5 => {
+                reth_stateless::fork_spec::ForkSpec::ByzantiumToConstantinopleAt5
+            }
+            ForkSpec::ByzantiumToConstantinopleFixAt5 => {
+                reth_stateless::fork_spec::ForkSpec::ByzantiumToConstantinopleFixAt5
+            }
+            ForkSpec::Constantinople => reth_stateless::fork_spec::ForkSpec::Constantinople,
+            ForkSpec::ConstantinopleFix => reth_stateless::fork_spec::ForkSpec::ConstantinopleFix,
+            ForkSpec::Istanbul => reth_stateless::fork_spec::ForkSpec::Istanbul,
+            ForkSpec::Berlin => reth_stateless::fork_spec::ForkSpec::Berlin,
+            ForkSpec::BerlinToLondonAt5 => reth_stateless::fork_spec::ForkSpec::BerlinToLondonAt5,
+            ForkSpec::London => reth_stateless::fork_spec::ForkSpec::London,
+            ForkSpec::Merge => reth_stateless::fork_spec::ForkSpec::Merge,
+            ForkSpec::Shanghai => reth_stateless::fork_spec::ForkSpec::Shanghai,
+            ForkSpec::MergeEOF => reth_stateless::fork_spec::ForkSpec::MergeEOF,
+            ForkSpec::MergeMeterInitCode => reth_stateless::fork_spec::ForkSpec::MergeMeterInitCode,
+            ForkSpec::MergePush0 => reth_stateless::fork_spec::ForkSpec::MergePush0,
+            ForkSpec::Cancun => reth_stateless::fork_spec::ForkSpec::Cancun,
+            ForkSpec::Prague => reth_stateless::fork_spec::ForkSpec::Prague,
+        }
     }
 }
 


### PR DESCRIPTION
This PR is a minimal mirroring of https://github.com/kevaundray/reth/pull/8 (e.g., cycle support isn't included), which builds on top of https://github.com/kevaundray/reth/tree/fusaka-devnet-2 which _looks like_ the branch from Reth for Fusaka Devnet 2.

Apart from #8 minimal changes, looks like reth upstream was also missing some Osaka spec detection for running test cases (I'll add in comments) -- that looks odd since it would mean `fusaka-devnet-2` wouldn't be able to run EEST `Osaka` fork tests. I'll ask someone from EEST which Reth branch they are using to keep track of Devnet 2 (I would have expected is this `fusaka-devnet-2` branch). (Edit: apparently this is indeed the correct branch, but tests are run with hive which doesn't require this deserialization)

Another quirk is that we have to fill EEST-benchmarks with 30M gas limit, since the current 36M default makes test fail since we can't have tx with gas bigger than 30M. (At some point this needs to be fixed in EEST).

Matching workload https://github.com/eth-act/zkevm-benchmark-workload/tree/jsign-fusaka-devnet-2