### PR TITLE
re-export bincode-able block

### DIFF
--- a/crates/stateless/src/lib.rs
+++ b/crates/stateless/src/lib.rs
@@ -65,6 +65,24 @@ pub use alloy_rpc_types_debug::ExecutionWitness;
 
 use reth_ethereum_primitives::Block;
 
+/// BincodeBlock is a wrapper around the Ethereum Block type that supports bincode serialization
+#[serde_with::serde_as]
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+pub struct BincodeBlock(
+    #[serde_as(
+        as = "reth_primitives_traits::serde_bincode_compat::Block<reth_ethereum_primitives::TransactionSigned, alloy_consensus::Header>"
+    )]
+    pub Block,
+);
+
+impl core::ops::Deref for BincodeBlock {
+    type Target = Block;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 /// `StatelessInput` is a convenience structure for serializing the input needed
 /// for the stateless validation function.
 #[serde_with::serde_as]


### PR DESCRIPTION
For `zkevm-benchmark-workload`, for a new guest program I want a version of `Block` that can be passed to stdin. For that, the type should support using Bincode for (de)serialization.

