### PR TITLE
Stateless chainspec

### DIFF
--- a/crates/stateless/Cargo.toml
+++ b/crates/stateless/Cargo.toml
@@ -18,6 +18,8 @@ alloy-rlp.workspace = true
 alloy-trie.workspace = true
 alloy-consensus.workspace = true
 alloy-rpc-types-debug.workspace = true
+alloy-eips.workspace = true
+alloy-genesis.workspace = true
 
 # reth
 reth-ethereum-consensus.workspace = true
@@ -30,6 +32,7 @@ reth-trie-common.workspace = true
 reth-trie-sparse.workspace = true
 reth-chainspec.workspace = true
 reth-consensus.workspace = true
+reth-network-peers.workspace = true
 tracing.workspace = true
 
 # misc

--- a/crates/stateless/src/chain_spec.rs
+++ b/crates/stateless/src/chain_spec.rs
@@ -1,0 +1,122 @@
+use core::fmt::Display;
+
+use alloc::{boxed::Box, vec::Vec};
+use alloy_consensus::Header;
+use alloy_eips::BlobScheduleBlobParams;
+use alloy_genesis::Genesis;
+use alloy_primitives::{Address, B256, U256};
+use reth_chainspec::{
+    BaseFeeParams, Chain, ChainHardforks, DepositContract, EthChainSpec, EthereumHardfork,
+    EthereumHardforks, ForkCondition, ForkFilter, ForkId, Hardfork, Hardforks, Head,
+};
+use reth_evm::eth::spec::EthExecutorSpec;
+
+#[derive(Debug, Clone)]
+pub struct ChainSpec {
+    pub chain: Chain,
+    pub hardforks: ChainHardforks,
+    pub deposit_contract_address: Option<Address>,
+    pub blob_params: BlobScheduleBlobParams,
+}
+
+impl EthereumHardforks for ChainSpec {
+    fn ethereum_fork_activation(&self, fork: EthereumHardfork) -> ForkCondition {
+        self.hardforks.get(fork).unwrap_or_default()
+    }
+}
+
+impl EthExecutorSpec for ChainSpec {
+    fn deposit_contract_address(&self) -> Option<Address> {
+        self.deposit_contract_address
+    }
+}
+
+impl Hardforks for ChainSpec {
+    fn fork<H: Hardfork>(&self, fork: H) -> ForkCondition {
+        self.hardforks.fork(fork)
+    }
+
+    fn forks_iter(&self) -> impl Iterator<Item = (&dyn Hardfork, ForkCondition)> {
+        self.hardforks.forks_iter()
+    }
+
+    fn fork_id(&self, _head: &Head) -> ForkId {
+        unimplemented!();
+    }
+
+    fn latest_fork_id(&self) -> ForkId {
+        unimplemented!()
+    }
+
+    fn fork_filter(&self, _head: Head) -> ForkFilter {
+        unimplemented!();
+    }
+}
+
+impl EthChainSpec for ChainSpec {
+    type Header = Header;
+
+    fn chain(&self) -> Chain {
+        self.chain
+    }
+
+    fn base_fee_params_at_block(&self, _: u64) -> BaseFeeParams {
+        unimplemented!()
+    }
+
+    fn base_fee_params_at_timestamp(&self, _: u64) -> BaseFeeParams {
+        unimplemented!()
+    }
+
+    fn blob_params_at_timestamp(&self, timestamp: u64) -> Option<alloy_eips::eip7840::BlobParams> {
+        if let Some(blob_param) = self.blob_params.active_scheduled_params_at_timestamp(timestamp) {
+            Some(*blob_param)
+        } else if self.is_osaka_active_at_timestamp(timestamp) {
+            Some(self.blob_params.osaka)
+        } else if self.is_prague_active_at_timestamp(timestamp) {
+            Some(self.blob_params.prague)
+        } else if self.is_cancun_active_at_timestamp(timestamp) {
+            Some(self.blob_params.cancun)
+        } else {
+            None
+        }
+    }
+
+    fn deposit_contract(&self) -> Option<&DepositContract> {
+        unimplemented!()
+    }
+
+    fn genesis_hash(&self) -> B256 {
+        unimplemented!()
+    }
+
+    fn prune_delete_limit(&self) -> usize {
+        unimplemented!()
+    }
+
+    fn display_hardforks(&self) -> Box<dyn Display> {
+        unimplemented!()
+    }
+
+    fn genesis_header(&self) -> &Self::Header {
+        unimplemented!()
+    }
+
+    fn genesis(&self) -> &Genesis {
+        unimplemented!()
+    }
+
+    fn bootnodes(&self) -> Option<Vec<reth_network_peers::node_record::NodeRecord>> {
+        unimplemented!()
+    }
+
+    fn final_paris_total_difficulty(&self) -> Option<U256> {
+        if let ForkCondition::TTD { total_difficulty, .. } =
+            self.ethereum_fork_activation(EthereumHardfork::Paris)
+        {
+            Some(total_difficulty)
+        } else {
+            None
+        }
+    }
+}

--- a/crates/stateless/src/fork_spec.rs
+++ b/crates/stateless/src/fork_spec.rs
@@ -1,7 +1,10 @@
+use alloy_eips::{eip6110::MAINNET_DEPOSIT_CONTRACT_ADDRESS, BlobScheduleBlobParams};
 // This is here so we don't pull in the EF-tests.
 // We need to think more about how we will parse in the chain-spec
-use reth_chainspec::{ChainSpec, ChainSpecBuilder};
+use reth_chainspec::{Chain, ChainSpecBuilder};
 use serde::{Deserialize, Serialize};
+
+use crate::chain_spec::ChainSpec;
 
 /// Fork specification.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Hash, Ord, Clone, Copy, Serialize, Deserialize)]
@@ -61,9 +64,9 @@ pub enum ForkSpec {
 
 impl From<ForkSpec> for ChainSpec {
     fn from(fork_spec: ForkSpec) -> Self {
-        let spec_builder = ChainSpecBuilder::mainnet();
+        let spec_builder = ChainSpecBuilder::default();
 
-        match fork_spec {
+        let hardforks = match fork_spec {
             ForkSpec::Frontier => spec_builder.frontier_activated(),
             ForkSpec::Homestead | ForkSpec::FrontierToHomesteadAt5 => {
                 spec_builder.homestead_activated()
@@ -72,17 +75,17 @@ impl From<ForkSpec> for ChainSpec {
                 spec_builder.tangerine_whistle_activated()
             }
             ForkSpec::EIP158 => spec_builder.spurious_dragon_activated(),
-            ForkSpec::Byzantium |
-            ForkSpec::EIP158ToByzantiumAt5 |
-            ForkSpec::ConstantinopleFix |
-            ForkSpec::ByzantiumToConstantinopleFixAt5 => spec_builder.byzantium_activated(),
+            ForkSpec::Byzantium
+            | ForkSpec::EIP158ToByzantiumAt5
+            | ForkSpec::ConstantinopleFix
+            | ForkSpec::ByzantiumToConstantinopleFixAt5 => spec_builder.byzantium_activated(),
             ForkSpec::Istanbul => spec_builder.istanbul_activated(),
             ForkSpec::Berlin => spec_builder.berlin_activated(),
             ForkSpec::London | ForkSpec::BerlinToLondonAt5 => spec_builder.london_activated(),
-            ForkSpec::Merge |
-            ForkSpec::MergeEOF |
-            ForkSpec::MergeMeterInitCode |
-            ForkSpec::MergePush0 => spec_builder.paris_activated(),
+            ForkSpec::Merge
+            | ForkSpec::MergeEOF
+            | ForkSpec::MergeMeterInitCode
+            | ForkSpec::MergePush0 => spec_builder.paris_activated(),
             ForkSpec::Shanghai => spec_builder.shanghai_activated(),
             ForkSpec::Cancun => spec_builder.cancun_activated(),
             ForkSpec::ByzantiumToConstantinopleAt5 | ForkSpec::Constantinople => {
@@ -91,5 +94,13 @@ impl From<ForkSpec> for ChainSpec {
             ForkSpec::Prague => spec_builder.prague_activated(),
         }
         .build()
+        .hardforks;
+
+        Self {
+            chain: Chain::mainnet(),
+            hardforks,
+            deposit_contract_address: Some(MAINNET_DEPOSIT_CONTRACT_ADDRESS),
+            blob_params: BlobScheduleBlobParams::default(),
+        }
     }
 }

--- a/crates/stateless/src/lib.rs
+++ b/crates/stateless/src/lib.rs
@@ -47,6 +47,7 @@ pub use validation::stateless_validation_with_trie;
 pub mod validation;
 pub(crate) mod witness_db;
 
+pub mod chain_spec;
 /// ForkSpec module
 /// This is needed because ChainSpec is not serializable (neither is genesis)
 ///


### PR DESCRIPTION
For context see: https://github.com/eth-act/zkevm-benchmark-workload/pull/123

This PR adds a stateless ChainSpec in order to workaround the big overhead we have when reading inputs.

This probably won't be the final design to upstream to reth. Feels like https://github.com/kevaundray/reth/pull/13 might be a better approach?

I think the main goal is to remove this big overhead from our benchmarks, and we can definitely polish how things look like in Reth to be upstreamable.