### PR TITLE
Add partial witness support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10331,6 +10331,7 @@ dependencies = [
  "serde",
  "serde_with",
  "thiserror 2.0.12",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10312,6 +10312,7 @@ name = "reth-stateless"
 version = "1.6.0"
 dependencies = [
  "alloy-consensus",
+ "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-debug",
@@ -10330,7 +10331,6 @@ dependencies = [
  "serde",
  "serde_with",
  "thiserror 2.0.12",
- "tracing",
 ]
 
 [[package]]

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -108,6 +108,23 @@ pub trait Executor<DB: Database>: Sized {
         Ok(BlockExecutionOutput { state: state.take_bundle(), result })
     }
 
+    /// Executes the EVM with the given input and accepts a state closure that is always invoked with
+    /// the EVM state after execution, even after failure.
+    fn execute_with_state_closure_always<F>(
+        mut self,
+        block: &RecoveredBlock<<Self::Primitives as NodePrimitives>::Block>,
+        mut f: F,
+    ) -> Result<BlockExecutionOutput<<Self::Primitives as NodePrimitives>::Receipt>, Self::Error>
+    where
+        F: FnMut(&State<DB>),
+    {
+        let result = self.execute_one(block);
+        let mut state = self.into_state();
+        f(&state);
+
+        Ok(BlockExecutionOutput { state: state.take_bundle(), result: result? })
+    }
+
     /// Executes the EVM with the given input and accepts a state hook closure that is invoked with
     /// the EVM state after execution.
     fn execute_with_state_hook<F>(

--- a/crates/stateless/Cargo.toml
+++ b/crates/stateless/Cargo.toml
@@ -31,8 +31,6 @@ reth-trie-common.workspace = true
 reth-trie-sparse.workspace = true
 reth-chainspec.workspace = true
 reth-consensus.workspace = true
-reth-network-peers.workspace = true
-tracing.workspace = true
 
 # misc
 thiserror.workspace = true

--- a/crates/stateless/Cargo.toml
+++ b/crates/stateless/Cargo.toml
@@ -37,3 +37,4 @@ thiserror.workspace = true
 itertools.workspace = true
 serde.workspace = true
 serde_with.workspace = true
+tracing.workspace = true

--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -253,7 +253,7 @@ fn run_case(
         // Consensus checks before block execution
         pre_execution_checks(chain_spec.clone(), &parent, block).map_err(|err| {
             let mut serialized_header = Vec::new();
-            parent.encode(&mut serialized_header);
+            parent.header().encode(&mut serialized_header);
             program_inputs.push((
                 block.clone(),
                 ExecutionWitness { headers: vec![serialized_header.into()], ..Default::default() },

--- a/testing/ef-tests/src/result.rs
+++ b/testing/ef-tests/src/result.rs
@@ -2,7 +2,10 @@
 
 use crate::Case;
 use reth_db::DatabaseError;
+use reth_ethereum_primitives::Block;
+use reth_primitives_traits::RecoveredBlock;
 use reth_provider::ProviderError;
+use reth_stateless::ExecutionWitness;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 
@@ -27,6 +30,8 @@ pub enum Error {
     BlockProcessingFailed {
         /// The block number for the block that failed
         block_number: u64,
+        /// The partial program inputs up to and including the block that failed
+        partial_program_inputs: Vec<(RecoveredBlock<Block>, ExecutionWitness)>,
         /// The specific error
         #[source]
         err: Box<dyn std::error::Error + Send + Sync>,
@@ -70,9 +75,10 @@ impl Error {
     /// Create a new [`Error::BlockProcessingFailed`] error.
     pub fn block_failed(
         block_number: u64,
+        partial_program_inputs: Vec<(RecoveredBlock<Block>, ExecutionWitness)>,
         err: impl std::error::Error + Send + Sync + 'static,
     ) -> Self {
-        Self::BlockProcessingFailed { block_number, err: Box::new(err) }
+        Self::BlockProcessingFailed { block_number, partial_program_inputs, err: Box::new(err) }
     }
 }
 


### PR DESCRIPTION
This PR adds support for returning a partially filled witness even if the block execution fails.

Workload side PR https://github.com/eth-act/zkevm-benchmark-workload/pull/150.