### PR TITLE
fmt to reduce diff noise

### DIFF
--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -462,8 +462,8 @@ impl ChainSpec {
             // We filter out TTD-based forks w/o a pre-known block since those do not show up in
             // the fork filter.
             Some(match condition {
-                ForkCondition::Block(block)
-                | ForkCondition::TTD { fork_block: Some(block), .. } => ForkFilterKey::Block(block),
+                ForkCondition::Block(block) |
+                ForkCondition::TTD { fork_block: Some(block), .. } => ForkFilterKey::Block(block),
                 ForkCondition::Timestamp(time) => ForkFilterKey::Time(time),
                 _ => return None,
             })
@@ -490,8 +490,8 @@ impl ChainSpec {
         for (_, cond) in self.hardforks.forks_iter() {
             // handle block based forks and the sepolia merge netsplit block edge case (TTD
             // ForkCondition with Some(block))
-            if let ForkCondition::Block(block)
-            | ForkCondition::TTD { fork_block: Some(block), .. } = cond
+            if let ForkCondition::Block(block) |
+            ForkCondition::TTD { fork_block: Some(block), .. } = cond
             {
                 if head.number >= block {
                     // skip duplicated hardforks: hardforks enabled at genesis block

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -107,8 +107,8 @@ pub trait Executor<DB: Database>: Sized {
         Ok(BlockExecutionOutput { state: state.take_bundle(), result })
     }
 
-    /// Executes the EVM with the given input and accepts a state closure that is always invoked with
-    /// the EVM state after execution, even after failure.
+    /// Executes the EVM with the given input and accepts a state closure that is always invoked
+    /// with the EVM state after execution, even after failure.
     fn execute_with_state_closure_always<F>(
         mut self,
         block: &RecoveredBlock<<Self::Primitives as NodePrimitives>::Block>,

--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -65,12 +65,12 @@ impl BlockchainTestCase {
     const fn excluded_fork(network: ForkSpec) -> bool {
         matches!(
             network,
-            ForkSpec::ByzantiumToConstantinopleAt5
-                | ForkSpec::Constantinople
-                | ForkSpec::ConstantinopleFix
-                | ForkSpec::MergeEOF
-                | ForkSpec::MergeMeterInitCode
-                | ForkSpec::MergePush0
+            ForkSpec::ByzantiumToConstantinopleAt5 |
+                ForkSpec::Constantinople |
+                ForkSpec::ConstantinopleFix |
+                ForkSpec::MergeEOF |
+                ForkSpec::MergeMeterInitCode |
+                ForkSpec::MergePush0
         )
     }
 
@@ -183,7 +183,8 @@ impl Case for BlockchainTestCase {
     }
 }
 
-/// Executes a single `BlockchainTest` returning an error as soon as any block has a consensus validation failure.
+/// Executes a single `BlockchainTest` returning an error as soon as any block has a consensus
+/// validation failure.
 ///
 /// A `BlockchainTest` represents a self-contained scenario:
 /// - It initializes a fresh blockchain state.
@@ -192,9 +193,10 @@ impl Case for BlockchainTestCase {
 ///   outcome.
 ///
 /// Returns:
-/// - `Ok(_)` if all blocks execute successfully, returning recovered blocks and full block execution witness.
-/// - `Err(Error)` if any block fails to execute correctly, returning a partial block execution witness if the
-///   error is of variant `BlockProcessingFailed`.
+/// - `Ok(_)` if all blocks execute successfully, returning recovered blocks and full block
+///   execution witness.
+/// - `Err(Error)` if any block fails to execute correctly, returning a partial block execution
+///   witness if the error is of variant `BlockProcessingFailed`.
 fn run_case(
     case: &BlockchainTest,
 ) -> Result<Vec<(RecoveredBlock<Block>, ExecutionWitness)>, Error> {

--- a/testing/ef-tests/src/models.rs
+++ b/testing/ef-tests/src/models.rs
@@ -355,10 +355,10 @@ impl From<ForkSpec> for ChainSpec {
                 .berlin_activated()
                 .with_fork(EthereumHardfork::London, ForkCondition::Block(5)),
             ForkSpec::London => spec_builder.london_activated(),
-            ForkSpec::Merge
-            | ForkSpec::MergeEOF
-            | ForkSpec::MergeMeterInitCode
-            | ForkSpec::MergePush0 => spec_builder.paris_activated(),
+            ForkSpec::Merge |
+            ForkSpec::MergeEOF |
+            ForkSpec::MergeMeterInitCode |
+            ForkSpec::MergePush0 => spec_builder.paris_activated(),
             ForkSpec::ParisToShanghaiAtTime15k => spec_builder
                 .paris_activated()
                 .with_fork(EthereumHardfork::Shanghai, ForkCondition::Timestamp(15_000)),


### PR DESCRIPTION
Our [current fork PR](https://github.com/kevaundray/reth/pull/8/files) shows some diffs that are just cargofmt differences -- fix that a bit so current diffs are clearer. 

`cargo +nightly fmt --all`